### PR TITLE
Modal code cleanup

### DIFF
--- a/src/commands/club/club.handler.ts
+++ b/src/commands/club/club.handler.ts
@@ -7,13 +7,13 @@ import { handleClubGive } from "./subcommands/give/club-give.handler";
 import { handleClubList } from "./subcommands/list/club-list.handler";
 import { handleClubRemove } from "./subcommands/remove/club-remove.handler";
 import { canBeGivenBy, isRole } from "./subcommands/utils";
-import { User, Guild } from "discord.js";
+import { User, Guild, MessageFlags } from "discord.js";
 
 export const handleClub = async (
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> => {
 	const { options, user, guild } = interaction;
-	await interaction.deferReply({ ephemeral: true });
+	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 	const clubParam = options.getString(ClubVariables.ROLE, true);
 

--- a/src/commands/community/community.handler.ts
+++ b/src/commands/community/community.handler.ts
@@ -18,13 +18,14 @@ import {
 	ApplicationCommandOptionChoiceData,
 	AutocompleteInteraction,
 	ChannelType,
+	MessageFlags,
 } from "discord.js";
 
 export const handleCommunity = async (
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> => {
 	const { options, user, guild } = interaction;
-	await interaction.deferReply({ ephemeral: true });
+	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 	const communityParam = options.getString(
 		CommunityVariables.COMMUNITY,

--- a/src/commands/courses/courses.handler.ts
+++ b/src/commands/courses/courses.handler.ts
@@ -44,7 +44,7 @@ export const handleCourses = async (
 
 	await interaction.reply({
 		content: lines.join(""),
-		flags: MessageFlags.Ephemeral
+		flags: MessageFlags.Ephemeral,
 	});
 	return;
 };

--- a/src/commands/courses/courses.handler.ts
+++ b/src/commands/courses/courses.handler.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { mappings } from "../../shared/alias-mappings";
 import { GuildChatInputCommandInteraction } from "../../shared/types/GuildChatInputCommandType";
 import { getAllCourseChannels } from "../../shared/utils/channel-utils";
@@ -43,7 +44,7 @@ export const handleCourses = async (
 
 	await interaction.reply({
 		content: lines.join(""),
-		ephemeral: true,
+		flags: MessageFlags.Ephemeral
 	});
 	return;
 };

--- a/src/commands/handle-commands.ts
+++ b/src/commands/handle-commands.ts
@@ -58,7 +58,8 @@ export const handleCommands = (): void => {
 			} else if (interaction.isModalSubmit()) {
 				const darkmode = await isDarkmode();
 
-				const guildModalSubmitInteraction = interaction as GuildModalSubmitInteraction;
+				const guildModalSubmitInteraction =
+					interaction as GuildModalSubmitInteraction;
 				const verifyModalCustomIds = VERIFY_MODAL_CUSTOM_IDS.map((id) =>
 					id.toString()
 				);
@@ -77,20 +78,27 @@ export const handleCommands = (): void => {
 					) {
 						await interaction.reply({
 							content: "You are already verified!",
-							flags: MessageFlags.Ephemeral
+							flags: MessageFlags.Ephemeral,
 						});
 						return;
 					}
 
 					switch (interaction.customId) {
 						case VerifyModalCustomIds.BEGIN:
-							await handleVerifyBegin(guildModalSubmitInteraction, darkmode);
+							await handleVerifyBegin(
+								guildModalSubmitInteraction,
+								darkmode
+							);
 							return;
 						case VerifyModalCustomIds.NOLLAN:
-							await handleVerifyNollan(guildModalSubmitInteraction);
+							await handleVerifyNollan(
+								guildModalSubmitInteraction
+							);
 							return;
 						case VerifyModalCustomIds.SUBMIT:
-							await handleVerifySubmit(guildModalSubmitInteraction);
+							await handleVerifySubmit(
+								guildModalSubmitInteraction
+							);
 							return;
 						default:
 							console.warn("Unexpected verify modal interaction");
@@ -170,7 +178,7 @@ const handleChatInputCommand = async (
 				case CommandNames.VERIFY:
 					await guildInteraction.reply({
 						content: "You are already verified!",
-						flags: MessageFlags.Ephemeral
+						flags: MessageFlags.Ephemeral,
 					});
 					return;
 				case CommandNames.JOIN:
@@ -219,7 +227,7 @@ const handleChatInputCommand = async (
 					: "Permission denied!\nYou first need to verify yourself using the '/verify' command.";
 				await guildInteraction.reply({
 					content: permissionDeniedMessage,
-					flags: MessageFlags.Ephemeral
+					flags: MessageFlags.Ephemeral,
 				});
 			} else {
 				throw new CommandNotFoundError(guildInteraction.commandName);
@@ -240,7 +248,10 @@ async function interaction_error_reply(
 			if (interaction.deferred || interaction.replied) {
 				await interaction.editReply({ content: message });
 			} else {
-				await interaction.reply({ content: message, flags: MessageFlags.Ephemeral });
+				await interaction.reply({
+					content: message,
+					flags: MessageFlags.Ephemeral,
+				});
 			}
 		}
 	} catch (error) {

--- a/src/commands/handle-commands.ts
+++ b/src/commands/handle-commands.ts
@@ -30,6 +30,7 @@ import { handleVerifyBegin } from "./verify/subcommands/begin/verify-begin.handl
 import { isDarkmode } from "../shared/utils/darkmode";
 import { handleVerifySubmit } from "./verify/subcommands/submit/verify-submit.handler";
 import { handleVerifyNollan } from "./verify/subcommands/nollan/verify-nollan.handler";
+import type { GuildModalSubmitInteraction } from "../shared/types/GuildModalSubmitInteraction";
 
 export const handleCommands = (): void => {
 	harmonyClient.on("interactionCreate", async (interaction) => {
@@ -56,6 +57,8 @@ export const handleCommands = (): void => {
 				await handleButtonInteraction(buttonInteraction);
 			} else if (interaction.isModalSubmit()) {
 				const darkmode = await isDarkmode();
+
+				const guildModalSubmitInteraction = interaction as GuildModalSubmitInteraction;
 				const verifyModalCustomIds = VERIFY_MODAL_CUSTOM_IDS.map((id) =>
 					id.toString()
 				);
@@ -81,13 +84,13 @@ export const handleCommands = (): void => {
 
 					switch (interaction.customId) {
 						case VerifyModalCustomIds.BEGIN:
-							await handleVerifyBegin(interaction, darkmode);
+							await handleVerifyBegin(guildModalSubmitInteraction, darkmode);
 							return;
 						case VerifyModalCustomIds.NOLLAN:
-							await handleVerifyNollan(interaction);
+							await handleVerifyNollan(guildModalSubmitInteraction);
 							return;
 						case VerifyModalCustomIds.SUBMIT:
-							await handleVerifySubmit(interaction);
+							await handleVerifySubmit(guildModalSubmitInteraction);
 							return;
 						default:
 							console.warn("Unexpected verify modal interaction");

--- a/src/commands/handle-commands.ts
+++ b/src/commands/handle-commands.ts
@@ -20,7 +20,7 @@ import {
 import { handleTranslateMsg } from "./translate/translateMsg.handler";
 import { handleClub } from "./club/club.handler";
 import { handleMessage } from "./message/message.handler";
-import { BaseInteraction } from "discord.js";
+import { BaseInteraction, MessageFlags } from "discord.js";
 import { handleKthId } from "./kthid/kthid.handler";
 import {
 	VERIFY_MODAL_CUSTOM_IDS,
@@ -77,7 +77,7 @@ export const handleCommands = (): void => {
 					) {
 						await interaction.reply({
 							content: "You are already verified!",
-							ephemeral: true,
+							flags: MessageFlags.Ephemeral
 						});
 						return;
 					}
@@ -170,7 +170,7 @@ const handleChatInputCommand = async (
 				case CommandNames.VERIFY:
 					await guildInteraction.reply({
 						content: "You are already verified!",
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral
 					});
 					return;
 				case CommandNames.JOIN:
@@ -219,7 +219,7 @@ const handleChatInputCommand = async (
 					: "Permission denied!\nYou first need to verify yourself using the '/verify' command.";
 				await guildInteraction.reply({
 					content: permissionDeniedMessage,
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral
 				});
 			} else {
 				throw new CommandNotFoundError(guildInteraction.commandName);
@@ -240,7 +240,7 @@ async function interaction_error_reply(
 			if (interaction.deferred || interaction.replied) {
 				await interaction.editReply({ content: message });
 			} else {
-				await interaction.reply({ content: message, ephemeral: true });
+				await interaction.reply({ content: message, flags: MessageFlags.Ephemeral });
 			}
 		}
 	} catch (error) {

--- a/src/commands/join/join.handler.ts
+++ b/src/commands/join/join.handler.ts
@@ -11,6 +11,7 @@ import { GuildChatInputCommandInteraction } from "../../shared/types/GuildChatIn
 import {
 	ApplicationCommandOptionChoiceData,
 	AutocompleteInteraction,
+	MessageFlags,
 	User,
 } from "discord.js";
 import { validCourseCode } from "../../shared/utils/valid-course-code";
@@ -25,7 +26,7 @@ export const handleJoin = async (
 		.toLowerCase();
 
 	if (aliasExists(courseCode as AliasName)) {
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		const updateCount = await handleChannelAlias(
 			interaction.guild,
 			interaction.user,

--- a/src/commands/kthid/kthid.handler.ts
+++ b/src/commands/kthid/kthid.handler.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { getKthIdByUserId } from "../../db/db";
 import { GuildChatInputCommandInteraction } from "../../shared/types/GuildChatInputCommandType";
 import { KthIdVariables } from "./kthid.variables";
@@ -7,7 +8,7 @@ export const handleKthId = async (
 ): Promise<void> => {
 	const { options } = interaction;
 	const user = options.getUser(KthIdVariables.USER, true);
-	await interaction.deferReply({ ephemeral: true });
+	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 	const kthId = await getKthIdByUserId(user.id);
 	if (!kthId) {
 		await interaction.editReply({

--- a/src/commands/leave/leave.handler.ts
+++ b/src/commands/leave/leave.handler.ts
@@ -1,4 +1,4 @@
-import { User } from "discord.js";
+import { MessageFlags, User } from "discord.js";
 import { AliasName } from "../../shared/alias-mappings";
 import { GuildChatInputCommandInteraction } from "../../shared/types/GuildChatInputCommandType";
 import {
@@ -18,7 +18,7 @@ export const handleLeave = async (
 		.trim()
 		.toLowerCase();
 	if (aliasExists(courseCode as AliasName)) {
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		const updateCount = await handleChannelAlias(
 			interaction.guild,
 			interaction.user,

--- a/src/commands/message/message.handler.ts
+++ b/src/commands/message/message.handler.ts
@@ -1,4 +1,4 @@
-import { Role, Snowflake } from "discord.js";
+import { MessageFlags, Role, Snowflake } from "discord.js";
 import { GuildChatInputCommandInteraction } from "../../shared/types/GuildChatInputCommandType";
 import { MessageVariables } from "./message.variables";
 import { sleep } from "../../shared/utils/channel-utils";
@@ -10,7 +10,7 @@ export const handleMessage = async (
 	const role = options.getRole(MessageVariables.ROLE, true) as Role;
 	const messageid = options.getString(MessageVariables.MESSAGEID, true);
 
-	await interaction.deferReply({ ephemeral: true });
+	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 	await interaction.guild.members.fetch();
 

--- a/src/commands/period/subcommands/roles/period-roles.handler.ts
+++ b/src/commands/period/subcommands/roles/period-roles.handler.ts
@@ -1,4 +1,4 @@
-import { GuildMember } from "discord.js";
+import { GuildMember, MessageFlags } from "discord.js";
 import { GuildChatInputCommandInteraction } from "../../../../shared/types/GuildChatInputCommandType";
 import { handleChannelAlias } from "../../../../shared/utils/channel-utils";
 import { getGradeYear } from "../../../../shared/utils/year";
@@ -9,7 +9,7 @@ export const handlePeriodRoles = async (
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> => {
 	const { options } = interaction;
-	await interaction.deferReply({ ephemeral: true });
+	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 	const period = options.getNumber(PeriodRolesVariables.PERIOD, true);
 
 	// Get guild from interaction

--- a/src/commands/translate/translateMsg.handler.ts
+++ b/src/commands/translate/translateMsg.handler.ts
@@ -1,4 +1,8 @@
-import { EmbedBuilder, MessageContextMenuCommandInteraction, MessageFlags } from "discord.js";
+import {
+	EmbedBuilder,
+	MessageContextMenuCommandInteraction,
+	MessageFlags,
+} from "discord.js";
 import {
 	isTranslationAvailable,
 	translateText,

--- a/src/commands/translate/translateMsg.handler.ts
+++ b/src/commands/translate/translateMsg.handler.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, MessageContextMenuCommandInteraction } from "discord.js";
+import { EmbedBuilder, MessageContextMenuCommandInteraction, MessageFlags } from "discord.js";
 import {
 	isTranslationAvailable,
 	translateText,
@@ -7,7 +7,7 @@ import {
 export const handleTranslateMsg = async (
 	interaction: MessageContextMenuCommandInteraction
 ): Promise<void> => {
-	await interaction.deferReply({ ephemeral: true });
+	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 	if (!isTranslationAvailable()) {
 		await interaction.editReply(

--- a/src/commands/verify/subcommands/begin/verify-begin.handler.ts
+++ b/src/commands/verify/subcommands/begin/verify-begin.handler.ts
@@ -7,13 +7,14 @@ import { VerifyBeginVariables } from "./verify-begin.variables";
 import * as db from "../../../../db/db";
 import { getHodisUser, isDangerOfNollan } from "../../../../shared/utils/hodis";
 import { VerifyingUser } from "../../../../shared/types/VerifyingUser";
-import { MessageFlags, ModalSubmitInteraction } from "discord.js";
+import { MessageFlags } from "discord.js";
+import { GuildModalSubmitInteraction } from "../../../../shared/types/GuildModalSubmitInteraction";
 
 // The basic logic of handleVerifyBegin() implemented in an
 // "interaction-agnostic manner".
 export async function handleVerifyBeginBase(
 	email: string,
-	interaction: GuildChatInputCommandInteraction | ModalSubmitInteraction,
+	interaction: GuildChatInputCommandInteraction | GuildModalSubmitInteraction,
 	darkmode: boolean,
 	code?: string
 ): Promise<void> {
@@ -98,7 +99,7 @@ export async function handleVerifyBeginBase(
 }
 
 export async function handleVerifyBegin(
-	interaction: GuildChatInputCommandInteraction | ModalSubmitInteraction,
+	interaction: GuildChatInputCommandInteraction | GuildModalSubmitInteraction,
 	darkmode: boolean
 ): Promise<void> {
 	if (interaction.isModalSubmit()) {
@@ -112,7 +113,7 @@ export async function handleVerifyBegin(
 		} else {
 			await handleVerifyBeginBase(email, interaction, darkmode);
 		}
-	} else {
+	} else if (interaction.isChatInputCommand()) {
 		const { options } = interaction;
 		const email = options.getString(VerifyBeginVariables.EMAIL, true);
 		const code = options.getString(VerifyBeginVariables.CODE, false);
@@ -127,5 +128,7 @@ export async function handleVerifyBegin(
 		} else {
 			await handleVerifyBeginBase(email, interaction, darkmode, code);
 		}
+	} else {
+		console.warn("Unexpected call to handleVerifyBegin(). Origin was neither a slash command, nor a modal submission.");
 	}
 }

--- a/src/commands/verify/subcommands/begin/verify-begin.handler.ts
+++ b/src/commands/verify/subcommands/begin/verify-begin.handler.ts
@@ -63,7 +63,7 @@ export async function handleVerifyBeginBase(
 				console.warn(error);
 				await interaction.reply({
 					content: "Something went wrong, please try again.",
-					flags: MessageFlags.Ephemeral
+					flags: MessageFlags.Ephemeral,
 				});
 			}
 			return;
@@ -129,6 +129,8 @@ export async function handleVerifyBegin(
 			await handleVerifyBeginBase(email, interaction, darkmode, code);
 		}
 	} else {
-		console.warn("Unexpected call to handleVerifyBegin(). Origin was neither a slash command, nor a modal submission.");
+		console.warn(
+			"Unexpected call to handleVerifyBegin(). Origin was neither a slash command, nor a modal submission."
+		);
 	}
 }

--- a/src/commands/verify/subcommands/begin/verify-begin.handler.ts
+++ b/src/commands/verify/subcommands/begin/verify-begin.handler.ts
@@ -63,7 +63,7 @@ export async function handleVerifyBeginBase(
 				console.warn(error);
 				await interaction.reply({
 					content: "Something went wrong, please try again.",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral
 				});
 			}
 			return;

--- a/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
+++ b/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
@@ -15,22 +15,6 @@ export async function handleVerifyNollanBase(
 ): Promise<void> {
 	let guild = interaction.guild;
 
-	// Verify modals should only exist on the server,
-	// so calls via slash command should remain unaffected.
-	/*
-	if (interaction.guild !== null) {
-		guild = interaction.guild;
-	} else {
-		console.warn(
-			"Verification failed due to guild being null (/verify nollan has failed)."
-		);
-		await interaction.editReply({
-			content: "Something went wrong, please try again.",
-		});
-		return;
-	}
-	*/
-
 	const { user } = interaction;
 	await interaction.deferReply({ ephemeral: true });
 

--- a/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
+++ b/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
@@ -14,7 +14,7 @@ export async function handleVerifyNollanBase(
 	interaction: GuildChatInputCommandInteraction | GuildModalSubmitInteraction,
 	nolleKod: string
 ): Promise<void> {
-	let guild = interaction.guild;
+	const guild = interaction.guild;
 
 	const { user } = interaction;
 	await interaction.deferReply({ flags: MessageFlags.Ephemeral });

--- a/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
+++ b/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
@@ -1,4 +1,4 @@
-import { ModalSubmitInteraction } from "discord.js";
+import { GuildModalSubmitInteraction } from "../../../../shared/types/GuildModalSubmitInteraction";
 import { GuildChatInputCommandInteraction } from "../../../../shared/types/GuildChatInputCommandType";
 import { addRolesOrRollback } from "../../../../shared/utils/atomic-roles";
 import {
@@ -10,13 +10,14 @@ import { verifyNolleCode } from "../../../../shared/utils/verify_nolle_code";
 import { VerifyNollanVariables } from "./verify-nollan.variables";
 
 export async function handleVerifyNollanBase(
-	interaction: GuildChatInputCommandInteraction | ModalSubmitInteraction,
+	interaction: GuildChatInputCommandInteraction | GuildModalSubmitInteraction,
 	nolleKod: string
 ): Promise<void> {
-	let guild = undefined;
+	let guild = interaction.guild;
 
 	// Verify modals should only exist on the server,
 	// so calls via slash command should remain unaffected.
+	/*
 	if (interaction.guild !== null) {
 		guild = interaction.guild;
 	} else {
@@ -28,6 +29,7 @@ export async function handleVerifyNollanBase(
 		});
 		return;
 	}
+	*/
 
 	const { user } = interaction;
 	await interaction.deferReply({ ephemeral: true });
@@ -71,7 +73,7 @@ export async function handleVerifyNollanBase(
 }
 
 export async function handleVerifyNollan(
-	interaction: GuildChatInputCommandInteraction | ModalSubmitInteraction
+	interaction: GuildChatInputCommandInteraction | GuildModalSubmitInteraction
 ): Promise<void> {
 	if (interaction.isModalSubmit()) {
 		const nolleKod = interaction.fields.getTextInputValue(
@@ -79,7 +81,7 @@ export async function handleVerifyNollan(
 		);
 
 		await handleVerifyNollanBase(interaction, nolleKod);
-	} else {
+	} else if (interaction.isChatInputCommand()) {
 		const { options } = interaction;
 		const nolleKod = options.getString(
 			VerifyNollanVariables.NOLLE_KOD,
@@ -87,5 +89,7 @@ export async function handleVerifyNollan(
 		);
 
 		await handleVerifyNollanBase(interaction, nolleKod);
+	} else {
+		console.warn("Unexpected call to handleVerifyNollan(). Origin was neither a slash command, nor a modal submission.");
 	}
 }

--- a/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
+++ b/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
@@ -75,6 +75,8 @@ export async function handleVerifyNollan(
 
 		await handleVerifyNollanBase(interaction, nolleKod);
 	} else {
-		console.warn("Unexpected call to handleVerifyNollan(). Origin was neither a slash command, nor a modal submission.");
+		console.warn(
+			"Unexpected call to handleVerifyNollan(). Origin was neither a slash command, nor a modal submission."
+		);
 	}
 }

--- a/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
+++ b/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../shared/utils/roles";
 import { verifyNolleCode } from "../../../../shared/utils/verify_nolle_code";
 import { VerifyNollanVariables } from "./verify-nollan.variables";
+import { MessageFlags } from "discord.js";
 
 export async function handleVerifyNollanBase(
 	interaction: GuildChatInputCommandInteraction | GuildModalSubmitInteraction,
@@ -16,7 +17,7 @@ export async function handleVerifyNollanBase(
 	let guild = interaction.guild;
 
 	const { user } = interaction;
-	await interaction.deferReply({ ephemeral: true });
+	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 	// Check if nØllan already verified
 	if (await hasRoleN0llan(user, guild)) {

--- a/src/commands/verify/subcommands/submit/verify-submit.handler.ts
+++ b/src/commands/verify/subcommands/submit/verify-submit.handler.ts
@@ -19,7 +19,7 @@ export async function handleVerifySubmitBase(
 ): Promise<void> {
 	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-	let guild = interaction.guild;
+	const guild = interaction.guild;
 
 	if (!messageIsToken(token)) {
 		await interaction.editReply({ content: "Not a valid code" });

--- a/src/commands/verify/subcommands/submit/verify-submit.handler.ts
+++ b/src/commands/verify/subcommands/submit/verify-submit.handler.ts
@@ -21,22 +21,6 @@ export async function handleVerifySubmitBase(
 
 	let guild = interaction.guild;
 
-	// Verify modals should only exist on the server,
-	// so calls via slash command should remain unaffected.
-	/*
-	if (interaction.guild !== null) {
-		guild = interaction.guild;
-	} else {
-		console.warn(
-			"Verification failed due to guild being null (/verify submit has failed)."
-		);
-		await interaction.editReply({
-			content: "Something went wrong, please try again.",
-		});
-		return;
-	}
-	*/
-
 	if (!messageIsToken(token)) {
 		await interaction.editReply({ content: "Not a valid code" });
 		return;

--- a/src/commands/verify/subcommands/submit/verify-submit.handler.ts
+++ b/src/commands/verify/subcommands/submit/verify-submit.handler.ts
@@ -1,4 +1,4 @@
-import { MessageFlags, ModalSubmitInteraction } from "discord.js";
+import { MessageFlags } from "discord.js";
 import { tokenUser } from "../../../../database-config";
 import * as db from "../../../../db/db";
 import { GuildChatInputCommandInteraction } from "../../../../shared/types/GuildChatInputCommandType";
@@ -11,17 +11,19 @@ import {
 } from "../../../../shared/utils/roles";
 import { messageIsToken, verifyUser } from "../util";
 import { VerifySubmitVariables } from "./verify-submit.variables";
+import { GuildModalSubmitInteraction } from "../../../../shared/types/GuildModalSubmitInteraction";
 
 export async function handleVerifySubmitBase(
-	interaction: GuildChatInputCommandInteraction | ModalSubmitInteraction,
+	interaction: GuildChatInputCommandInteraction | GuildModalSubmitInteraction,
 	token: string
 ): Promise<void> {
 	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-	let guild = undefined;
+	let guild = interaction.guild;
 
 	// Verify modals should only exist on the server,
 	// so calls via slash command should remain unaffected.
+	/*
 	if (interaction.guild !== null) {
 		guild = interaction.guild;
 	} else {
@@ -33,6 +35,7 @@ export async function handleVerifySubmitBase(
 		});
 		return;
 	}
+	*/
 
 	if (!messageIsToken(token)) {
 		await interaction.editReply({ content: "Not a valid code" });
@@ -84,14 +87,14 @@ export async function handleVerifySubmitBase(
 }
 
 export async function handleVerifySubmit(
-	interaction: GuildChatInputCommandInteraction | ModalSubmitInteraction
+	interaction: GuildChatInputCommandInteraction | GuildModalSubmitInteraction
 ): Promise<void> {
 	if (interaction.isModalSubmit()) {
 		const verificationCode =
 			interaction.fields.getTextInputValue("verifySubmitCode");
 
 		await handleVerifySubmitBase(interaction, verificationCode);
-	} else {
+	} else if (interaction.isChatInputCommand()) {
 		const { options } = interaction;
 		const verificationCode = options.getString(
 			VerifySubmitVariables.VERIFICATION_CODE,
@@ -99,5 +102,7 @@ export async function handleVerifySubmit(
 		);
 
 		await handleVerifySubmitBase(interaction, verificationCode);
+	} else {
+		console.warn("Unexpected call to handleVerifyNollan(). Origin was neither a slash command, nor a modal submission.");
 	}
 }

--- a/src/commands/verify/subcommands/submit/verify-submit.handler.ts
+++ b/src/commands/verify/subcommands/submit/verify-submit.handler.ts
@@ -87,6 +87,8 @@ export async function handleVerifySubmit(
 
 		await handleVerifySubmitBase(interaction, verificationCode);
 	} else {
-		console.warn("Unexpected call to handleVerifyNollan(). Origin was neither a slash command, nor a modal submission.");
+		console.warn(
+			"Unexpected call to handleVerifyNollan(). Origin was neither a slash command, nor a modal submission."
+		);
 	}
 }

--- a/src/commands/verify/verify.handler.ts
+++ b/src/commands/verify/verify.handler.ts
@@ -26,7 +26,7 @@ export const handleVerify = async (
 			else
 				interaction.reply({
 					content: "Nøllan has already been dealt with...",
-					flags: MessageFlags.Ephemeral
+					flags: MessageFlags.Ephemeral,
 				});
 			return;
 		default:

--- a/src/commands/verify/verify.handler.ts
+++ b/src/commands/verify/verify.handler.ts
@@ -6,6 +6,7 @@ import { handleVerifySubmit } from "./subcommands/submit/verify-submit.handler";
 import { VerifySubcommandNames } from "./verify-subcommands.names";
 import { isDarkmode } from "../../shared/utils/darkmode";
 import { clientIsLight } from "../../shared/types/light-client";
+import { MessageFlags } from "discord.js";
 
 export const handleVerify = async (
 	interaction: GuildChatInputCommandInteraction
@@ -25,7 +26,7 @@ export const handleVerify = async (
 			else
 				interaction.reply({
 					content: "Nøllan has already been dealt with...",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral
 				});
 			return;
 		default:

--- a/src/shared/types/GuildModalSubmitInteraction.ts
+++ b/src/shared/types/GuildModalSubmitInteraction.ts
@@ -1,0 +1,3 @@
+import type { ModalSubmitInteraction, Guild } from "discord.js";
+
+export type GuildModalSubmitInteraction = Omit<ModalSubmitInteraction, "guild"> & { guild: Guild };

--- a/src/shared/types/GuildModalSubmitInteraction.ts
+++ b/src/shared/types/GuildModalSubmitInteraction.ts
@@ -1,3 +1,6 @@
 import type { ModalSubmitInteraction, Guild } from "discord.js";
 
-export type GuildModalSubmitInteraction = Omit<ModalSubmitInteraction, "guild"> & { guild: Guild };
+export type GuildModalSubmitInteraction = Omit<
+	ModalSubmitInteraction,
+	"guild"
+> & { guild: Guild };

--- a/src/shared/utils/channel-utils.ts
+++ b/src/shared/utils/channel-utils.ts
@@ -7,6 +7,7 @@ import {
 	Guild,
 	PermissionFlagsBits,
 	User,
+	MessageFlags,
 } from "discord.js";
 import { AliasName, mappings } from "../alias-mappings";
 import { GuildButtonOrCommandInteraction } from "../types/GuildButtonOrCommandInteraction";
@@ -78,7 +79,7 @@ export const handleChannel = async (
 ): Promise<void> => {
 	noInteraction = noInteraction ?? false;
 	if (!noInteraction) {
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 	}
 
 	await interaction.guild.channels.fetch();


### PR DESCRIPTION
See pull request #185. Got rid of "dirty fixes" by adding a GuildModalSubmitInteraction similar to GuildChatInputCommandInteraction (i.e. it extends ModalSubmitInteraction with a 'guild' field).

Additionally, updated code to use 'flags: MessageFlags.Ephemeral' instead of 'ephemeral: true', since the latter is deprecated.