### PR TITLE
Exit verifyUser early if client is light

### DIFF
--- a/src/commands/verify/subcommands/begin/verify-begin.handler.ts
+++ b/src/commands/verify/subcommands/begin/verify-begin.handler.ts
@@ -57,7 +57,7 @@ export async function handleVerifyBeginBase(
 			try {
 				// Should always be true, so long as the command is only used in a guild.
 				if (interaction.guild !== null) {
-					verifyUser(user, interaction.guild, kthId);
+					verifyUser(interaction.user, interaction.guild, kthId, interaction.client);
 				}
 			} catch (error) {
 				console.warn(error);

--- a/src/commands/verify/subcommands/begin/verify-begin.handler.ts
+++ b/src/commands/verify/subcommands/begin/verify-begin.handler.ts
@@ -57,7 +57,12 @@ export async function handleVerifyBeginBase(
 			try {
 				// Should always be true, so long as the command is only used in a guild.
 				if (interaction.guild !== null) {
-					verifyUser(interaction.user, interaction.guild, kthId, interaction.client);
+					verifyUser(
+						interaction.user,
+						interaction.guild,
+						kthId,
+						interaction.client
+					);
 				}
 			} catch (error) {
 				console.warn(error);

--- a/src/commands/verify/subcommands/submit/verify-submit.handler.ts
+++ b/src/commands/verify/subcommands/submit/verify-submit.handler.ts
@@ -50,7 +50,7 @@ export async function handleVerifySubmitBase(
 				setPingRoles(interaction.user, guild),
 			]);
 		} else {
-			await verifyUser(interaction.user, guild, kthId);
+			await verifyUser(interaction.user, guild, kthId, interaction.client);
 		}
 	} catch (error) {
 		console.warn(error);

--- a/src/commands/verify/subcommands/submit/verify-submit.handler.ts
+++ b/src/commands/verify/subcommands/submit/verify-submit.handler.ts
@@ -50,7 +50,12 @@ export async function handleVerifySubmitBase(
 				setPingRoles(interaction.user, guild),
 			]);
 		} else {
-			await verifyUser(interaction.user, guild, kthId, interaction.client);
+			await verifyUser(
+				interaction.user,
+				guild,
+				kthId,
+				interaction.client
+			);
 		}
 	} catch (error) {
 		console.warn(error);

--- a/src/commands/verify/subcommands/util.ts
+++ b/src/commands/verify/subcommands/util.ts
@@ -32,8 +32,7 @@ export const verifyUser = async (
 
 	await setRoleVerified(user, guild);
 
-	if (clientIsLight(client))
-		return;
+	if (clientIsLight(client)) return;
 
 	const { year, yearRole } = await extractYearFromUser(kthId);
 	const userHasYearRole = await hasAnyYearRole(user, guild);

--- a/src/commands/verify/subcommands/util.ts
+++ b/src/commands/verify/subcommands/util.ts
@@ -1,4 +1,4 @@
-import { Guild, User } from "discord.js";
+import { Client, Guild, User } from "discord.js";
 import {
 	hasAnyYearRole,
 	hasRole,
@@ -12,6 +12,7 @@ import { extractYearFromUser } from "../../../shared/utils/hodis";
 import { mapYearToAlias } from "../../../shared/utils/alias_to_year_mapper";
 import { handleChannelAlias } from "../../../shared/utils/channel-utils";
 import { joinChannel } from "../../join/join.handler";
+import { clientIsLight } from "../../../shared/types/light-client";
 
 export const isKthEmail = (messageText: string): boolean =>
 	new RegExp(/^[a-zA-Z0-9]+@kth[.]se$/).test(messageText);
@@ -22,13 +23,18 @@ export const messageIsToken = (messageText: string): RegExpMatchArray | null =>
 export const verifyUser = async (
 	user: User,
 	guild: Guild,
-	kthId: string
+	kthId: string,
+	client: Client
 ): Promise<void> => {
 	console.log(
 		`Verified user by kth email. kthid="${kthId}" user.id="${user.id}" user.username="${user.username}"`
 	);
 
 	await setRoleVerified(user, guild);
+
+	if (clientIsLight(client))
+		return;
+
 	const { year, yearRole } = await extractYearFromUser(kthId);
 	const userHasYearRole = await hasAnyYearRole(user, guild);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,9 @@ async function main(): Promise<void> {
 		harmonyClient.once("ready", () => console.log("Logged into Harmony"));
 		await harmonyClient.login(process.env.DISCORD_BOT_TOKEN);
 
-		harmonyClient.on("guildMemberAdd", (member) => userJoined(member, harmonyClient));
+		harmonyClient.on("guildMemberAdd", (member) =>
+			userJoined(member, harmonyClient)
+		);
 		harmonyClient.on("interactionCreate", async (interaction) => {
 			await handleInteractions(interaction);
 		});
@@ -53,7 +55,9 @@ async function main(): Promise<void> {
 		);
 		await harmonyLightClient.login(process.env.DISCORD_LIGHT_BOT_TOKEN);
 
-		harmonyLightClient.on("guildMemberAdd", (member) => userJoined(member, harmonyLightClient));
+		harmonyLightClient.on("guildMemberAdd", (member) =>
+			userJoined(member, harmonyLightClient)
+		);
 		harmonyLightClient.on("interactionCreate", async (interaction) => {
 			await handleInteractions(interaction);
 		});

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
 		harmonyClient.once("ready", () => console.log("Logged into Harmony"));
 		await harmonyClient.login(process.env.DISCORD_BOT_TOKEN);
 
-		harmonyClient.on("guildMemberAdd", (member) => userJoined(member));
+		harmonyClient.on("guildMemberAdd", (member) => userJoined(member, harmonyClient));
 		harmonyClient.on("interactionCreate", async (interaction) => {
 			await handleInteractions(interaction);
 		});
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
 		);
 		await harmonyLightClient.login(process.env.DISCORD_LIGHT_BOT_TOKEN);
 
-		harmonyLightClient.on("guildMemberAdd", (member) => userJoined(member));
+		harmonyLightClient.on("guildMemberAdd", (member) => userJoined(member, harmonyLightClient));
 		harmonyLightClient.on("interactionCreate", async (interaction) => {
 			await handleInteractions(interaction);
 		});

--- a/src/shared/utils/userJoined.ts
+++ b/src/shared/utils/userJoined.ts
@@ -1,16 +1,19 @@
-import { GuildMember } from "discord.js";
+import { Client, GuildMember } from "discord.js";
 import * as db from "../../db/db";
 import { verifyUser } from "../../commands/verify/subcommands/util";
 import { isDangerOfNollan } from "./hodis";
 import { isDarkmode } from "./darkmode";
 
-export const userJoined = async (member: GuildMember): Promise<void> => {
+export const userJoined = async (
+	member: GuildMember,
+	client: Client
+): Promise<void> => {
 	const kthId = await db.getKthIdByUserId(member.id);
 	const darkmode = await isDarkmode();
 
 	if (kthId !== null && !(await isDangerOfNollan(kthId, darkmode))) {
 		try {
-			verifyUser(member.user, member.guild, kthId);
+			verifyUser(member.user, member.guild, kthId, client);
 		} catch (error) {
 			console.warn(error);
 		}


### PR DESCRIPTION
This fixes the issue where the light bot tries to give users roles that don't exist on the servers with the light bot.