### PR TITLE
Fix: Unverified users able to use course buttons

### DIFF
--- a/src/commands/buttons/subcommands/courses/buttons-courses.handler.ts
+++ b/src/commands/buttons/subcommands/courses/buttons-courses.handler.ts
@@ -11,6 +11,8 @@ import {
 	handleChannelAlias,
 	isMemberOfAlias,
 } from "../../../../shared/utils/channel-utils";
+import { hasRoleVerified } from "../../../../shared/utils/roles";
+
 
 export async function handleButtonsCourses(
 	interaction: GuildChatInputCommandInteraction
@@ -34,10 +36,19 @@ export async function handleButtonsCourses(
 export async function handleCourseButtonInteraction(
 	interaction: GuildButtonInteraction
 ): Promise<void> {
+	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+	const isVerified: boolean = await hasRoleVerified(interaction.user, interaction.guild);
+	if (!isVerified) {
+		await interaction.editReply({
+			content: "Only verified users can join courses."
+		});
+		return;
+	}
+
 	const courseCode = interaction.customId;
 	const alias = courseCode as AliasName;
 	if (aliasExists(alias)) {
-		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		const joining = !(await isMemberOfAlias(
 			interaction.guild,
 			interaction.user.id,

--- a/src/commands/buttons/subcommands/courses/buttons-courses.handler.ts
+++ b/src/commands/buttons/subcommands/courses/buttons-courses.handler.ts
@@ -13,7 +13,6 @@ import {
 } from "../../../../shared/utils/channel-utils";
 import { hasRoleVerified } from "../../../../shared/utils/roles";
 
-
 export async function handleButtonsCourses(
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> {
@@ -38,10 +37,13 @@ export async function handleCourseButtonInteraction(
 ): Promise<void> {
 	await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-	const isVerified: boolean = await hasRoleVerified(interaction.user, interaction.guild);
+	const isVerified: boolean = await hasRoleVerified(
+		interaction.user,
+		interaction.guild
+	);
 	if (!isVerified) {
 		await interaction.editReply({
-			content: "Only verified users can join courses."
+			content: "Only verified users can join courses.",
 		});
 		return;
 	}


### PR DESCRIPTION
Resolves #194.

Added check to `handleCourseButtonInteraction()` to ensure that users that do not have the `verified` role cannot use the coruse buttons and are shown an error message when using the buttons.