### PR TITLE
KTH-id please, nØllan

### DIFF
--- a/src/commands/buttons/subcommands/verify/buttons-verify.handler.ts
+++ b/src/commands/buttons/subcommands/verify/buttons-verify.handler.ts
@@ -14,7 +14,6 @@ export async function handleButtonsVerify(
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> {
 	const mottagning = await isDarkmode();
-
 	let labels: string[];
 
 	if (mottagning) {
@@ -88,13 +87,26 @@ export async function handleVerifyButtonInteraction(
 				.setCustomId(VerifyModalCustomIds.NOLLAN)
 				.setTitle("nØllan...");
 
+			const emailInput = new TextInputBuilder()
+				.setCustomId("verifyNollanEmail")
+				.setLabel("Vad är din KTH-mejladress, nØllan?")
+				.setStyle(TextInputStyle.Short)
+				.setRequired(true);
+
+			var actionRow =
+				new ActionRowBuilder<TextInputBuilder>().addComponents(
+					emailInput
+				);
+
+			modal.addComponents(actionRow);
+
 			const nollekodInput = new TextInputBuilder()
-				.setCustomId("VerifyNollanNollekod")
+				.setCustomId("verifyNollanNollekod")
 				.setLabel("Vad är din nØllekod, nØllan?")
 				.setStyle(TextInputStyle.Short)
 				.setRequired(true);
 
-			const actionRow =
+			var actionRow =
 				new ActionRowBuilder<TextInputBuilder>().addComponents(
 					nollekodInput
 				);

--- a/src/commands/nollegrupp/subcommands/add/nollegrupp-add.handler.ts
+++ b/src/commands/nollegrupp/subcommands/add/nollegrupp-add.handler.ts
@@ -5,8 +5,14 @@ import { NollegruppAddVariables } from "./nollegrupp-add.variables";
 export async function handleNollegruppAdd(
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> {
-	const name = interaction.options.getString(NollegruppAddVariables.NAME, true);
-	const code = interaction.options.getString(NollegruppAddVariables.CODE, true);
+	const name = interaction.options.getString(
+		NollegruppAddVariables.NAME,
+		true
+	);
+	const code = interaction.options.getString(
+		NollegruppAddVariables.CODE,
+		true
+	);
 
 	let result = false;
 

--- a/src/commands/nollegrupp/subcommands/add/nollegrupp-add.handler.ts
+++ b/src/commands/nollegrupp/subcommands/add/nollegrupp-add.handler.ts
@@ -5,8 +5,8 @@ import { NollegruppAddVariables } from "./nollegrupp-add.variables";
 export async function handleNollegruppAdd(
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> {
-	const name = interaction.options.getString(NollegruppAddVariables.NAME);
-	const code = interaction.options.getString(NollegruppAddVariables.CODE);
+	const name = interaction.options.getString(NollegruppAddVariables.NAME, true);
+	const code = interaction.options.getString(NollegruppAddVariables.CODE, true);
 
 	let result = false;
 

--- a/src/commands/nollegrupp/subcommands/remove/nollegrupp-remove.handler.ts
+++ b/src/commands/nollegrupp/subcommands/remove/nollegrupp-remove.handler.ts
@@ -5,7 +5,10 @@ import { NollegruppRemoveVariables } from "./nollegrupp-remove.variables";
 export async function handleNollegruppRemove(
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> {
-	const name = interaction.options.getString(NollegruppRemoveVariables.NAME, true);
+	const name = interaction.options.getString(
+		NollegruppRemoveVariables.NAME,
+		true
+	);
 
 	// name is never null.
 	if (name != null) {

--- a/src/commands/nollegrupp/subcommands/remove/nollegrupp-remove.handler.ts
+++ b/src/commands/nollegrupp/subcommands/remove/nollegrupp-remove.handler.ts
@@ -5,7 +5,7 @@ import { NollegruppRemoveVariables } from "./nollegrupp-remove.variables";
 export async function handleNollegruppRemove(
 	interaction: GuildChatInputCommandInteraction
 ): Promise<void> {
-	const name = interaction.options.getString(NollegruppRemoveVariables.NAME);
+	const name = interaction.options.getString(NollegruppRemoveVariables.NAME, true);
 
 	// name is never null.
 	if (name != null) {

--- a/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
+++ b/src/commands/verify/subcommands/nollan/verify-nollan.handler.ts
@@ -33,7 +33,8 @@ export async function handleVerifyNollanBase(
 	// Hopefully nØllan knows how to activate their mail address.
 	if (!isKthEmail(email)) {
 		await interaction.editReply({
-			content: "Var vänlig och skriv in en *riktig* KTH-mejladress, nØllan.",
+			content:
+				"Var vänlig och skriv in en *riktig* KTH-mejladress, nØllan.",
 		});
 		return;
 	}
@@ -78,9 +79,7 @@ export async function handleVerifyNollan(
 		const nolleKod = interaction.fields.getTextInputValue(
 			"verifyNollanNollekod"
 		);
-		const email = interaction.fields.getTextInputValue(
-			"verifyNollanEmail"
-		);
+		const email = interaction.fields.getTextInputValue("verifyNollanEmail");
 
 		await handleVerifyNollanBase(email, interaction, nolleKod);
 	} else if (interaction.isChatInputCommand()) {
@@ -89,10 +88,7 @@ export async function handleVerifyNollan(
 			VerifyNollanVariables.NOLLE_KOD,
 			true
 		);
-		const email = options.getString(
-			VerifyNollanVariables.EMAIL,
-			true
-		);
+		const email = options.getString(VerifyNollanVariables.EMAIL, true);
 
 		await handleVerifyNollanBase(email, interaction, nolleKod);
 	} else {

--- a/src/commands/verify/subcommands/nollan/verify-nollan.variables.ts
+++ b/src/commands/verify/subcommands/nollan/verify-nollan.variables.ts
@@ -1,3 +1,4 @@
 export enum VerifyNollanVariables {
+	EMAIL = "email",
 	NOLLE_KOD = "nolle-kod",
 }

--- a/src/commands/verify/verify.command.ts
+++ b/src/commands/verify/verify.command.ts
@@ -81,6 +81,14 @@ export async function createVerifyCommand(
 				)
 				.addStringOption((option) =>
 					option
+						.setName(VerifyNollanVariables.EMAIL)
+						.setDescription(
+							"Din KTH-mejladress"
+						)
+						.setRequired(true)
+				)
+				.addStringOption((option) =>
+					option
 						.setName(VerifyNollanVariables.NOLLE_KOD)
 						.setDescription(
 							"Den hemliga koden du fått från din dadda"

--- a/src/commands/verify/verify.command.ts
+++ b/src/commands/verify/verify.command.ts
@@ -82,9 +82,7 @@ export async function createVerifyCommand(
 				.addStringOption((option) =>
 					option
 						.setName(VerifyNollanVariables.EMAIL)
-						.setDescription(
-							"Din KTH-mejladress"
-						)
+						.setDescription("Din KTH-mejladress")
 						.setRequired(true)
 				)
 				.addStringOption((option) =>

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -125,10 +125,7 @@ export async function formatNollegruppData(): Promise<string> {
 	return output;
 }
 
-export async function insertNollan(
-	kthId: string,
-	discordId: string
-) {
+export async function insertNollan(kthId: string, discordId: string) {
 	try {
 		await sql`insert into nollan (kth_id, discord_id) values (${kthId}, ${discordId})`;
 	} catch (err) {

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -19,7 +19,15 @@ export async function init(): Promise<void> {
 		create table if not exists nollegrupp (
 			name text primary key,
 			code text unique not null
-		)
+		);
+	`;
+
+	// Initialise table table for nØllan's KTH-ids and Discord ids.
+	await sql`
+		create table if not exists nollan (
+			kth_id text primary key,
+			discord_id text unique not null
+		);
 	`;
 }
 
@@ -115,4 +123,30 @@ export async function formatNollegruppData(): Promise<string> {
 	});
 
 	return output;
+}
+
+export async function insertNollan(
+	kthId: string,
+	discordId: string
+) {
+	try {
+		await sql`insert into nollan (kth_id, discord_id) values (${kthId}, ${discordId})`;
+	} catch (err) {
+		if (err instanceof PostgresError && err.code == "23505") {
+			// code for unique key violation
+			return false;
+		}
+		throw err;
+	}
+	return true;
+}
+
+// nØllan is "special"...
+export async function getKthIdByNolleId(
+	discordId: string
+): Promise<string | null> {
+	const users =
+		await sql`select kth_id from nollan where discord_id = ${discordId}`;
+	if (!users.length) return null;
+	return users[0].kth_id;
 }

--- a/src/shared/utils/userJoined.ts
+++ b/src/shared/utils/userJoined.ts
@@ -3,6 +3,7 @@ import * as db from "../../db/db";
 import { verifyUser } from "../../commands/verify/subcommands/util";
 import { isDangerOfNollan } from "./hodis";
 import { isDarkmode } from "./darkmode";
+import { setN0llanRole } from "./roles";
 
 export const userJoined = async (
 	member: GuildMember,
@@ -16,6 +17,17 @@ export const userJoined = async (
 			verifyUser(member.user, member.guild, kthId, isLight);
 		} catch (error) {
 			console.warn(error);
+		}
+	}
+
+	if (darkmode) {
+		let kthId = await db.getKthIdByNolleId(member.id);
+		if (kthId !== null && !isLight) {
+			try {
+				setN0llanRole(member.user, member.guild);
+			} catch (error) {
+				console.warn(error);
+			}
 		}
 	}
 };


### PR DESCRIPTION
Resolves #198.
- Added parameter `email` to `/verify nollan` and the corresponding verification modal. nØllan now has to enter a valid KTH-email address on verification (no Hodis check, though).
- nØllan's KTH-id and Discord id are added to the `nollan` table in the database.
- nØllan that leaves the server and returns after performing the nØllan verification process regain the nØllan role by checking if they are in the `nollan` table.